### PR TITLE
OpenTelemetry support + fix for headers

### DIFF
--- a/src/Eventual.RabbitMq/Eventual.RabbitMq.csproj
+++ b/src/Eventual.RabbitMq/Eventual.RabbitMq.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.0.5</Version>
+    <Version>0.0.9</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Eventual.RabbitMq/Middleware/Publishing/PrepareMessageContextForPublish.cs
+++ b/src/Eventual.RabbitMq/Middleware/Publishing/PrepareMessageContextForPublish.cs
@@ -5,6 +5,7 @@
     using Configuration;
     using Fox.Middleware;
     using Infrastructure.Serialization;
+    using Tracing;
 
     public class PrepareMessageContextForPublish<T> : IPublishAction<T>
     {

--- a/src/Eventual.RabbitMq/Middleware/Publishing/PrepareMessageContextForPublish.cs
+++ b/src/Eventual.RabbitMq/Middleware/Publishing/PrepareMessageContextForPublish.cs
@@ -28,14 +28,21 @@
             rbc.Body = encoded;
 
             var properties = rbc.Properties;
+            properties.Type = typeof(T).FullName;
             properties.AppId = _busConfiguration.ServiceName;
             properties.DeliveryMode = 2; //topic
             properties.CorrelationId = context.Message.CorrelationId;
             properties.MessageId = context.Message.Id;
-            //properties.ContentEncoding = ""
+
+            //set headers
+            foreach (var entry in context.Message.Metadata)
+            {
+                properties.Headers.Add(entry.Key, entry.Value);
+            }
+
+            //retry headers
             properties.Headers.Add("count", 0);
             properties.Headers.Add("retry.in", 0);
-
             for (var i = 0; i < _busConfiguration.RetryBackOff.Count; i++)
             {
                 properties.Headers.Add($"retry.{i + 1}.after", _busConfiguration.RetryBackOff[i]);

--- a/src/Eventual.RabbitMq/Middleware/Subscribing/ReadMessageFromQueueIntoContext.cs
+++ b/src/Eventual.RabbitMq/Middleware/Subscribing/ReadMessageFromQueueIntoContext.cs
@@ -21,7 +21,13 @@
         {
             var rbc = (RabbitMqMessageReceivedContext<T>)context;
             var properties = rbc.Payload.BasicProperties;
-            var headers = properties?.Headers?.ToDictionary(key => key.Key, pair => pair.Value.ToString()) 
+            var headers = properties?.Headers?.ToDictionary(key => key.Key, pair =>
+                          {
+                              var val = pair.Value as byte[];
+                              return val == null 
+                                  ? pair.Value.ToString() 
+                                  : Encoding.UTF8.GetString(val);
+                          }) 
                           ?? new Dictionary<string, string>();
 
             var content = Encoding.UTF8.GetString(rbc.Payload.Body.ToArray());

--- a/src/Eventual/Configuration/Factory.cs
+++ b/src/Eventual/Configuration/Factory.cs
@@ -60,7 +60,7 @@
 
             //middleware
             //publishing
-            services.AddSingleton(typeof(MessagePublishContextMiddleware<>));
+            services.AddSingleton(typeof(PublishedMessageMiddleware<>));
             services.AddSingleton(svc => svc.GetService<Setup>().PublishContextActions);
             services.AddTransient(typeof(InvokePublish<>));
             services.AddTransient(typeof(OpenTelemetryPublishAction<>));

--- a/src/Eventual/Configuration/Factory.cs
+++ b/src/Eventual/Configuration/Factory.cs
@@ -11,6 +11,7 @@
     using Middleware;
     using Middleware.Publishing;
     using Middleware.Subscribing;
+    using Tracing;
 
     public abstract class Factory
     {
@@ -53,15 +54,20 @@
                 setup.Subscribe(registeredController.ImplementationType);
             }
 
+            //telemetry
+            services.AddSingleton<Telemetry>();
+            services.AddScoped<TelemetryContext>();
 
             //middleware
             //publishing
             services.AddSingleton(typeof(MessagePublishContextMiddleware<>));
             services.AddSingleton(svc => svc.GetService<Setup>().PublishContextActions);
             services.AddTransient(typeof(InvokePublish<>));
+            services.AddTransient(typeof(OpenTelemetryPublishAction<>));
 
             var pa = setup.PublishContextActions;
             pa.InvokePublisherAction ??= typeof(InvokePublish<>);
+            pa.ApmAction ??= typeof(OpenTelemetryPublishAction<>);
 
             //subscriptions
             services.AddSingleton(typeof(ReceivedMessageMiddleware<>));
@@ -69,11 +75,13 @@
             services.AddTransient(typeof(InvokeConsumer<>));
             services.AddTransient(typeof(LogReceivedMessage<>));
             services.AddTransient(typeof(DefaultMessageAck<>));
+            services.AddTransient(typeof(OpenTelemetryConsumeAction<>));
 
             var ra = setup.ReceivedContextActions;
             ra.DeadLetterAction ??= typeof(DefaultMessageAck<>);
             ra.LoggingAction ??= typeof(LogReceivedMessage<>);
             ra.InvokeConsumerAction ??= typeof(InvokeConsumer<>);
+            ra.ApmAction ??= typeof(OpenTelemetryConsumeAction<>);
 
         }
     }

--- a/src/Eventual/Eventual.csproj
+++ b/src/Eventual/Eventual.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>0.0.5</Version>
+    <Version>0.0.9</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Eventual/Eventual.csproj
+++ b/src/Eventual/Eventual.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0-rc.1.21451.13" />
   </ItemGroup>
 
 </Project>

--- a/src/Eventual/Message.cs
+++ b/src/Eventual/Message.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using Tracing;
 
     public class Message<T>
     {
@@ -28,11 +29,29 @@
         /// a user defined correlation id. please try to embrace the <see cref="OpenTelemetryTraceId"/>
         /// </summary>
         public string CorrelationId { get; set; }
-        
+
         /// <summary>
         /// the open telemetry trace id, W3C format (this is normally generated from a parent context)
         /// </summary>
-        public string OpenTelemetryTraceId { get; set; }
+        public string OpenTelemetryTraceId
+        {
+            get
+            {
+                Metadata.TryGetValue(Telemetry.Header, out var value);
+                return value;
+            }
+            set
+            {
+                if (Metadata.ContainsKey(Telemetry.Header))
+                {
+                    Metadata[Telemetry.Header] = value;
+                }
+                else
+                {
+                    Metadata.Add(Telemetry.Header, value);
+                }
+            }
+        }
 
         /// <summary>
         /// any meta data (headers) that should accompany this message for down stream subscribers to process.

--- a/src/Eventual/Message.cs
+++ b/src/Eventual/Message.cs
@@ -14,16 +14,35 @@
         {
             DateTime = DateTime.UtcNow;
             Id = Guid.NewGuid().ToString("D");
-            CorrelationId = Id;
             Metadata = new Dictionary<string, string>();
         }
 
         public DateTime DateTime { get; set; }
-        public string Id { get; set; }
-        public string CorrelationId { get; set; }
 
+        /// <summary>
+        /// a unique Id for this message instance
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// a user defined correlation id. please try to embrace the <see cref="OpenTelemetryTraceId"/>
+        /// </summary>
+        public string CorrelationId { get; set; }
+        
+        /// <summary>
+        /// the open telemetry trace id, W3C format (this is normally generated from a parent context)
+        /// </summary>
+        public string OpenTelemetryTraceId { get; set; }
+
+        /// <summary>
+        /// any meta data (headers) that should accompany this message for down stream subscribers to process.
+        /// </summary>
         public IDictionary<string, string> Metadata { get; set; }
 
+
+        /// <summary>
+        /// main payload to be published
+        /// </summary>
         public T Body { get; set; }
     }
 }

--- a/src/Eventual/Middleware/IDispatcher.cs
+++ b/src/Eventual/Middleware/IDispatcher.cs
@@ -31,7 +31,7 @@
 
         public Task ProcessMessage<T>(MessagePublishContext<T> publishContext)
         {
-            var middleware = _serviceProvider.GetService<MessagePublishContextMiddleware<T>>();
+            var middleware = _serviceProvider.GetService<PublishedMessageMiddleware<T>>();
             return middleware.Execute(_serviceProvider, publishContext);
         }
     }

--- a/src/Eventual/Middleware/Publishing/MessagePublishContextMiddleware.cs
+++ b/src/Eventual/Middleware/Publishing/MessagePublishContextMiddleware.cs
@@ -4,11 +4,11 @@
     using System.Threading.Tasks;
     using Fox.Middleware;
 
-    public class MessagePublishContextMiddleware<T> : IMiddleware<MessagePublishContext<T>>
+    public class PublishedMessageMiddleware<T> : IMiddleware<MessagePublishContext<T>>
     {
         private readonly Middleware<MessagePublishContext<T>> _internalMiddleware;
 
-        public MessagePublishContextMiddleware(PublishContextActions actions)
+        public PublishedMessageMiddleware(PublishContextActions actions)
         {
             _internalMiddleware = new Middleware<MessagePublishContext<T>>();
 

--- a/src/Eventual/Middleware/Subscribing/ReceivedMessageMiddleware.cs
+++ b/src/Eventual/Middleware/Subscribing/ReceivedMessageMiddleware.cs
@@ -15,8 +15,8 @@
             _internalMiddleware = new Middleware<MessageReceivedContext<T>>();
 
             _internalMiddleware.Add(MakeGeneric<T>(actions.ReadMessageFromQueueIntoContextAction));
-            if (actions.LoggingAction != null) _internalMiddleware.Add(MakeGeneric<T>(actions.LoggingAction));
             if (actions.ApmAction != null) _internalMiddleware.Add(MakeGeneric<T>(actions.ApmAction));
+            if (actions.LoggingAction != null) _internalMiddleware.Add(MakeGeneric<T>(actions.LoggingAction));
             if (actions.DeadLetterAction != null) _internalMiddleware.Add(MakeGeneric<T>(actions.DeadLetterAction));
 
             foreach (var customAction in actions.CustomActions)

--- a/src/Eventual/Tracing/OpenTelemetryConsumeAction.cs
+++ b/src/Eventual/Tracing/OpenTelemetryConsumeAction.cs
@@ -1,0 +1,71 @@
+﻿namespace Eventual.Tracing
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Fox.Middleware;
+    using Middleware;
+    using Middleware.Subscribing;
+
+    public class OpenTelemetryConsumeAction<T> : IConsumeAction<T>
+    {
+        private readonly Telemetry _telemetry;
+        private readonly TelemetryContext _context;
+
+        public OpenTelemetryConsumeAction(Telemetry telemetry, TelemetryContext context)
+        {
+            _telemetry = telemetry;
+            _context = context;
+        }
+
+        public async Task Execute(MessageReceivedContext<T> context, Next<MessageReceivedContext<T>> next)
+        {
+            if (!context.Message.Metadata.TryGetValue(Telemetry.Header, out var traceId))
+            {
+                traceId = context.Message.CorrelationId;
+            }
+
+
+            var activity = traceId != null
+                ? _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Consumer, traceId)
+                : _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Consumer);
+
+            Activity.Current ??= activity;
+            _context.CorrelationId = traceId;
+
+            if (activity == null)
+            {
+                await next(context);
+                return;
+            }
+
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.AddTag("adapter", "rabbitmq");
+
+            using (activity)
+            {
+                activity.Start();
+                try
+                {
+                    await next(context);
+                    activity.SetStatus(ActivityStatusCode.Ok);
+                }
+                catch (Exception e)
+                {
+                    activity.SetStatus(ActivityStatusCode.Error, e.Message);
+                    activity.SetTag("otel.status_code", "ERROR");
+                    activity.SetTag("otel.status_description", e.Message);
+
+                    var tags = new List<KeyValuePair<string, object>>();
+                    tags.Add(new KeyValuePair<string, object>("message", e.Message));
+                    tags.Add(new KeyValuePair<string, object>("stack", e.StackTrace));
+
+                    ActivityEvent @event = new ActivityEvent("error", tags: new ActivityTagsCollection(tags));
+                    activity.AddEvent(@event);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
+++ b/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
@@ -1,0 +1,55 @@
+﻿namespace Eventual.Tracing
+{
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Fox.Middleware;
+    using Middleware;
+    using Middleware.Publishing;
+
+    public class OpenTelemetryPublishAction<T> : IPublishAction<T>
+    {
+        private readonly Telemetry _telemetry;
+        private readonly TelemetryContext _context;
+
+        public OpenTelemetryPublishAction(Telemetry telemetry, TelemetryContext context)
+        {
+            _telemetry = telemetry;
+            _context = context;
+        }
+
+        public async Task Execute(MessagePublishContext<T> context, Next<MessagePublishContext<T>> next)
+        {
+            string parentId;
+            var parent = Activity.Current;
+
+            if (parent != null && !string.IsNullOrEmpty(parent.Id) && parent.IdFormat == ActivityIdFormat.W3C)
+            {
+                parentId = parent.Id;
+            }
+            else
+            {
+                parentId = _context?.CorrelationId;
+            }
+
+            var activity = parentId != null
+                ? _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Producer, parentId)
+                : _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Producer);
+
+            if (activity == null)
+            {
+                await next(context);
+                return;
+            }
+
+            activity.SetIdFormat(ActivityIdFormat.W3C);
+
+            using (activity)
+            {
+                activity.Start();
+                context.Message.CorrelationId = activity.Id;
+                if (!context.Message.Metadata.ContainsKey(Telemetry.Header)) context.Message.Metadata.Add(Telemetry.Header, activity.Id);
+                await next(context);
+            }
+        }
+    }
+}

--- a/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
+++ b/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
@@ -32,8 +32,8 @@
             }
 
             var activity = parentId != null
-                ? _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Producer, parentId)
-                : _telemetry.ActivitySource.CreateActivity(typeof(T).FullName, ActivityKind.Producer);
+                ? _telemetry.ActivitySource.StartActivity(typeof(T).FullName, ActivityKind.Producer, parentId)
+                : _telemetry.ActivitySource.StartActivity(typeof(T).FullName, ActivityKind.Producer);
 
             //user can define -> we try the parent message -> finally we re-use the current id
             context.Message.CorrelationId ??= _context?.CorrelationId ?? context.Message.Id;
@@ -44,16 +44,16 @@
                 return;
             }
 
-            activity.SetIdFormat(ActivityIdFormat.W3C);
+            //activity.SetIdFormat(ActivityIdFormat.W3C);
             activity.AddTag("adapter", "eventual");
             activity.AddTag("message.id", context.Message.Id);
             activity.AddTag("message.correlation.id", context.Message.CorrelationId);
 
             using (activity)
             {
-                activity.Start();
+                //activity.Start();
                 context.Message.OpenTelemetryTraceId = activity.Id;
-                if (!context.Message.Metadata.ContainsKey(Telemetry.Header)) context.Message.Metadata.Add(Telemetry.Header, activity.Id);
+                //if (!context.Message.Metadata.ContainsKey(Telemetry.Header)) context.Message.Metadata.Add(Telemetry.Header, activity.Id);
                 await next(context);
             }
         }

--- a/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
+++ b/src/Eventual/Tracing/OpenTelemetryPublishAction.cs
@@ -28,7 +28,7 @@
             }
             else
             {
-                parentId = _context?.CorrelationId;
+                parentId = _context?.OpenTelemetryTraceId;
             }
 
             var activity = parentId != null
@@ -42,11 +42,13 @@
             }
 
             activity.SetIdFormat(ActivityIdFormat.W3C);
+            activity.AddTag("adapter", "eventual");
 
             using (activity)
             {
                 activity.Start();
-                context.Message.CorrelationId = activity.Id;
+                context.Message.CorrelationId = _context.CorrelationId ?? context.Message.Id;
+                context.Message.OpenTelemetryTraceId = activity.Id;
                 if (!context.Message.Metadata.ContainsKey(Telemetry.Header)) context.Message.Metadata.Add(Telemetry.Header, activity.Id);
                 await next(context);
             }

--- a/src/Eventual/Tracing/Telemetry.cs
+++ b/src/Eventual/Tracing/Telemetry.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Text;
-
-namespace Eventual.Tracing
+﻿namespace Eventual.Tracing
 {
     using System.Diagnostics;
+    using System;
 
     /// <summary>
     /// this is where we control the <see cref="ActivitySource"/>
@@ -22,7 +20,7 @@ namespace Eventual.Tracing
             ActivitySource = new ActivitySource(Name);
         }
 
-        public static string Header = "x-open-telemetry";
+        public static string Header = "open.telemetry";
         public static string Name = "eventual.opentelemetry";
 
         public ActivitySource ActivitySource { get; }

--- a/src/Eventual/Tracing/Telemetry.cs
+++ b/src/Eventual/Tracing/Telemetry.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text;
+
+namespace Eventual.Tracing
+{
+    using System.Diagnostics;
+
+    /// <summary>
+    /// this is where we control the <see cref="ActivitySource"/>
+    /// </summary>
+    /// <remarks>
+    /// https://github.com/open-telemetry/opentelemetry-dotnet/issues/947
+    /// https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-5.0
+    /// https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/src/OpenTelemetry.Api/README.md
+    /// https://docs.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing-collection-walkthroughs
+    /// https://www.mytechramblings.com/posts/getting-started-with-opentelemetry-and-dotnet-core/
+    /// </remarks>
+    public class Telemetry : IDisposable
+    {
+        public Telemetry()
+        {
+            ActivitySource = new ActivitySource(Name);
+        }
+
+        public static string Header = "x-open-telemetry";
+        public static string Name = "eventual.opentelemetry";
+
+        public ActivitySource ActivitySource { get; }
+
+        public void Dispose()
+        {
+            ActivitySource?.Dispose();
+        }
+    }
+}

--- a/src/Eventual/Tracing/TelemetryContext.cs
+++ b/src/Eventual/Tracing/TelemetryContext.cs
@@ -1,0 +1,7 @@
+﻿namespace Eventual.Tracing
+{
+    public class TelemetryContext
+    {
+        public string CorrelationId { get; set; }
+    }
+}

--- a/src/Eventual/Tracing/TelemetryContext.cs
+++ b/src/Eventual/Tracing/TelemetryContext.cs
@@ -2,6 +2,7 @@
 {
     public class TelemetryContext
     {
+        public string OpenTelemetryTraceId { get; set; }
         public string CorrelationId { get; set; }
     }
 }


### PR DESCRIPTION
note this is a breaking change

correlation id can be set by the client application, however opentelemetry is preferred.